### PR TITLE
Migrate away from composite unit test pub action

### DIFF
--- a/.github/workflows/step-build.yml
+++ b/.github/workflows/step-build.yml
@@ -44,6 +44,6 @@ jobs:
           testFilter: Category!=LocalTest
     - name: Publish Unit Test Results
       if: ${{ github.actor != 'dependabot[bot]' }}
-      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
       with:
         files: "**/TestResults/*.xml"


### PR DESCRIPTION
https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2#running-as-a-composite-action

Closes #81
