### PR TITLE
Add `GITHUB_TOKEN` to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/blocked-issue.yml
+++ b/.github/workflows/blocked-issue.yml
@@ -10,6 +10,9 @@ on:
       - created
       - edited
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   add-blocked-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-develop.yml
+++ b/.github/workflows/branch-develop.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/step-*.yml'
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     uses: ./.github/workflows/step-version.yml

--- a/.github/workflows/branch-feature.yml
+++ b/.github/workflows/branch-feature.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/step-*.yml'
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     if: startsWith(github.head_ref, 'feature/') || github.head_ref == 'master'

--- a/.github/workflows/branch-hotfix.yml
+++ b/.github/workflows/branch-hotfix.yml
@@ -7,6 +7,9 @@ on:
       - master
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     if: startsWith(github.head_ref, 'hotfix/')

--- a/.github/workflows/branch-master.yml
+++ b/.github/workflows/branch-master.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     uses: ./.github/workflows/step-version.yml

--- a/.github/workflows/branch-release.yml
+++ b/.github/workflows/branch-release.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/step-*.yml'
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     if: startsWith(github.head_ref, 'release/')

--- a/.github/workflows/completed-feature-workflow.yml
+++ b/.github/workflows/completed-feature-workflow.yml
@@ -5,6 +5,9 @@ on:
     branches: [ develop ]
     types: [closed]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   update-merged-issue-issues:
     if: github.event.pull_request.merged_by != '' && github.actor != 'dependabot[bot]' && startsWith(github.head_ref, 'feature/issue-')

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -13,6 +13,9 @@ on:
         description: 'The patch version you want to release.'
         required: true
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
 
   draft-new-release:

--- a/.github/workflows/in-progress-feature-workflow.yml
+++ b/.github/workflows/in-progress-feature-workflow.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - feature/issue-*
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   update-in-progress-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-configurer.yml
+++ b/.github/workflows/label-configurer.yml
@@ -6,6 +6,9 @@ on:
       - ".github/workflows/label-configurer.yml"
       - ".github/labels.yml"
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-issue-workflow.yml
+++ b/.github/workflows/new-issue-workflow.yml
@@ -4,6 +4,9 @@ on:
     types:
       - opened
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   update-new-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-dependabot.yml
+++ b/.github/workflows/test-dependabot.yml
@@ -7,6 +7,9 @@ on:
       - develop
   workflow_dispatch:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   get-version:
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `GITHUB_TOKEN` environment variable to all GitHub Actions workflows to prevent rate limiting issues with the GitHub API (#129)
+
 ## [1.1.0.6] - 2025-04-21
 
 ### Added


### PR DESCRIPTION
to prevent rate limiting issues with the GitHub API

Fixes #129
